### PR TITLE
Add CLI output check and test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/redact_unified.py
+++ b/redact_unified.py
@@ -381,6 +381,9 @@ def main():
     parser.add_argument('output', nargs='?', help='Output PDF for CLI mode')
     args = parser.parse_args()
 
+    if args.input and not args.output:
+        parser.error('output PDF required in CLI mode')
+
     if args.gui or not args.input:
         run_gui()
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,13 @@
+import subprocess
+from pathlib import Path
+import unittest
+
+class CLIMissingOutputTest(unittest.TestCase):
+    def test_missing_output(self):
+        script = Path(__file__).resolve().parents[1] / 'redact_unified.py'
+        result = subprocess.run(['python', str(script), 'input.pdf'], capture_output=True, text=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn('output PDF required in CLI mode', result.stderr)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure CLI mode requires an output file
- ignore Python cache files
- test CLI argument validation

## Testing
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_685e3ebbf574832193d826a64ca19f8b