### PR TITLE
Load saved regions on PDF open

### DIFF
--- a/redact_unified.py
+++ b/redact_unified.py
@@ -278,6 +278,11 @@ class PDFRedactorGUI:
         self.page_label.config(text=f"1 / {len(self.doc)}")
         stem = Path(filename).stem
         self.region_store = RegionStore(stem)
+        latest = JSONStore.find_latest_file(stem, 'regions')
+        if latest and latest.exists():
+            data = json.loads(latest.read_text())
+            self.region_store.regions = data.get('regions', {})
+            self.region_store.protect = data.get('protect', {})
         self.display_page()
 
     def display_page(self):


### PR DESCRIPTION
## Summary
- load latest stored regions when a PDF is opened

## Testing
- `python -m py_compile redact_unified.py`

------
https://chatgpt.com/codex/tasks/task_e_685e3efc45508321a7ef60d3ee60b2d9